### PR TITLE
Fix server name in root route response message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import version from '../package.json'
 
 const app = new Hono()
 	.get('/', (c) => {
-		return c.text(`Project LoL Server is running! | v ${version.version}`)
+		return c.text(`Hexcuit Server is running! | v ${version.version}`)
 	})
 	.route('/rank', rankRouter)
 


### PR DESCRIPTION
Update the server name in the root route response to reflect the correct application name.