### PR TITLE
feat(ci): add automated deployment to Cloudflare Workers

### DIFF
--- a/.changeset/add-cd-pipeline.md
+++ b/.changeset/add-cd-pipeline.md
@@ -1,0 +1,10 @@
+---
+"@hexcuit/server": patch
+---
+
+Add automated deployment to Cloudflare Workers
+
+- Add D1 migrations step after release
+- Add Cloudflare Workers deploy step
+- Remove unused lolRanks table from schema
+- Use frozen-lockfile for reproducible builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '24.11.1'
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build
@@ -45,3 +45,21 @@ jobs:
           title: 'ci release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Drizzle kit
+        if: steps.changesets.outputs.published == 'true'
+        run: bun run generate
+      
+      - name: D1 Migrations
+        if: steps.changesets.outputs.published == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: d1 migrations apply hexcuit --remote
+
+      - name: Deploy to Cloudflare Workers
+        if: steps.changesets.outputs.published == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy

--- a/drizzle/0003_redundant_shockwave.sql
+++ b/drizzle/0003_redundant_shockwave.sql
@@ -1,0 +1,1 @@
+DROP TABLE `lol_ranks`;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,153 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "41546b05-801d-4628-9049-be7d46e4b917",
+	"prevId": "68846bdc-ee36-4b0d-9ad4-365304cba099",
+	"tables": {
+		"lol_rank": {
+			"name": "lol_rank",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"division": {
+					"name": "division",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"lol_rank_discord_id_users_discord_id_fk": {
+					"name": "lol_rank_discord_id_users_discord_id_fk",
+					"tableFrom": "lol_rank",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"riot_accounts": {
+			"name": "riot_accounts",
+			"columns": {
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tagLine": {
+					"name": "tagLine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"riot_accounts_discord_id_unique": {
+					"name": "riot_accounts_discord_id_unique",
+					"columns": ["discord_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"riot_accounts_discord_id_users_discord_id_fk": {
+					"name": "riot_accounts_discord_id_users_discord_id_fk",
+					"tableFrom": "riot_accounts",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1759122867152,
 			"tag": "0002_gifted_captain_universe",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1763699961368,
+			"tag": "0003_redundant_shockwave",
+			"breakpoints": true
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"check:fix": "biome check --fix --unsafe",
 		"cf-typegen": "wrangler types --env-interface CloudflareBindings",
 		"typecheck": "tsc --noEmit",
+		"generate": "drizzle-kit generate",
 		"version": "changeset version && bun i --lockfile-only",
 		"release": "changeset publish"
 	},

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from 'drizzle-orm'
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { createInsertSchema } from 'drizzle-zod'
 
 export const users = sqliteTable('users', {
@@ -36,37 +36,11 @@ export const riotAccounts = sqliteTable('riot_accounts', {
 	region: text('region').notNull(),
 })
 
-export const lolRanks = sqliteTable('lol_ranks', {
-	id: text('id').primaryKey(),
-	puuid: text('puuid').references(() => riotAccounts.puuid, {
-		onDelete: 'cascade',
-		onUpdate: 'cascade',
-	}),
-	queueType: text('queue_type').notNull(),
-	tier: text('tier').notNull(),
-	rank: text('rank').notNull(),
-	leaguePoints: integer('leaguePoints').notNull(),
-	wins: integer('wins').notNull(),
-	losses: integer('losses').notNull(),
-	lastUpdated: text('last_updated')
-		.notNull()
-		.default(sql`(current_timestamp)`)
-		.$onUpdateFn(() => sql`(current_timestamp)`),
-})
-
-export const lolRanksRelations = relations(lolRanks, ({ one }) => ({
-	riotAccount: one(riotAccounts, {
-		fields: [lolRanks.puuid],
-		references: [riotAccounts.puuid],
-	}),
-}))
-
-export const riotAccountsRelations = relations(riotAccounts, ({ one, many }) => ({
+export const riotAccountsRelations = relations(riotAccounts, ({ one }) => ({
 	user: one(users, {
 		fields: [riotAccounts.discordId],
 		references: [users.discordId],
 	}),
-	lolRanks: many(lolRanks),
 }))
 
 export const usersRelations = relations(users, ({ one }) => ({

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
-	"name": "project-lol-server",
+	"name": "hexcuit-server",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-11-11",
 	"observability": {
@@ -9,7 +9,8 @@
 	"d1_databases": [
 		{
 			"binding": "DB",
-			"database_name": "project-lol",
+			"database_name": "hexcuit",
+			"database_id": "a20ff5ef-8539-444c-8098-e92ffa65d32b",
 			"migrations_dir": "drizzle"
 		}
 	]


### PR DESCRIPTION
## Summary
- Add D1 migrations step after release publish
- Add Cloudflare Workers deploy step after migrations
- Remove unused `lolRanks` table from schema
- Use `--frozen-lockfile` for reproducible builds

## Test plan
- [ ] Verify CI workflow triggers on changeset release
- [ ] Confirm D1 migrations apply correctly
- [ ] Validate Cloudflare Workers deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated deployment pipeline to Cloudflare Workers with database migration execution.

* **Chores**
  * Updated project configuration and database schema.
  * Enhanced build reproducibility with frozen lockfile enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->