### PR TITLE
feat: add recruitment API endpoints

### DIFF
--- a/.changeset/add-recruit-api.md
+++ b/.changeset/add-recruit-api.md
@@ -1,0 +1,11 @@
+---
+"@hexcuit/server": minor
+---
+
+Add recruitment API endpoints for custom game recruitment feature
+
+- POST /recruit - Create recruitment
+- GET /recruit/:id - Get recruitment details
+- POST /recruit/join - Join recruitment
+- POST /recruit/leave - Leave recruitment
+- POST /recruit/:id/close - Close recruitment

--- a/drizzle/0004_bumpy_zemo.sql
+++ b/drizzle/0004_bumpy_zemo.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `recruitment_participants` (
+	`id` text PRIMARY KEY NOT NULL,
+	`recruitment_id` text NOT NULL,
+	`discord_id` text NOT NULL,
+	`joined_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`recruitment_id`) REFERENCES `recruitments`(`id`) ON UPDATE cascade ON DELETE cascade,
+	FOREIGN KEY (`discord_id`) REFERENCES `users`(`discord_id`) ON UPDATE cascade ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `recruitments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`guild_id` text NOT NULL,
+	`channel_id` text NOT NULL,
+	`message_id` text NOT NULL,
+	`creator_id` text NOT NULL,
+	`anonymous` text DEFAULT 'false' NOT NULL,
+	`capacity` text DEFAULT '10' NOT NULL,
+	`start_time` text,
+	`status` text DEFAULT 'open' NOT NULL,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	`updated_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`creator_id`) REFERENCES `users`(`discord_id`) ON UPDATE cascade ON DELETE cascade
+);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,313 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "7e39c406-b021-4234-8cfa-8b192e0579a5",
+	"prevId": "41546b05-801d-4628-9049-be7d46e4b917",
+	"tables": {
+		"lol_rank": {
+			"name": "lol_rank",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"division": {
+					"name": "division",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"lol_rank_discord_id_users_discord_id_fk": {
+					"name": "lol_rank_discord_id_users_discord_id_fk",
+					"tableFrom": "lol_rank",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitment_participants": {
+			"name": "recruitment_participants",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recruitment_id": {
+					"name": "recruitment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"joined_at": {
+					"name": "joined_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitment_participants_recruitment_id_recruitments_id_fk": {
+					"name": "recruitment_participants_recruitment_id_recruitments_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "recruitments",
+					"columnsFrom": ["recruitment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"recruitment_participants_discord_id_users_discord_id_fk": {
+					"name": "recruitment_participants_discord_id_users_discord_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitments": {
+			"name": "recruitments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message_id": {
+					"name": "message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"anonymous": {
+					"name": "anonymous",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'false'"
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'10'"
+				},
+				"start_time": {
+					"name": "start_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitments_creator_id_users_discord_id_fk": {
+					"name": "recruitments_creator_id_users_discord_id_fk",
+					"tableFrom": "recruitments",
+					"tableTo": "users",
+					"columnsFrom": ["creator_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"riot_accounts": {
+			"name": "riot_accounts",
+			"columns": {
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tagLine": {
+					"name": "tagLine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"riot_accounts_discord_id_unique": {
+					"name": "riot_accounts_discord_id_unique",
+					"columns": ["discord_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"riot_accounts_discord_id_users_discord_id_fk": {
+					"name": "riot_accounts_discord_id_users_discord_id_fk",
+					"tableFrom": "riot_accounts",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1763699961368,
 			"tag": "0003_redundant_shockwave",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1765181150573,
+			"tag": "0004_bumpy_zemo",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { rankRouter } from '@/routes/rank'
+import { recruitRouter } from '@/routes/recruit'
 import version from '../package.json'
 
 const app = new Hono()
@@ -7,6 +8,7 @@ const app = new Hono()
 		return c.text(`Hexcuit Server is running! | v ${version.version}`)
 	})
 	.route('/rank', rankRouter)
+	.route('/recruit', recruitRouter)
 
 export type AppType = typeof app
 

--- a/src/routes/recruit/index.ts
+++ b/src/routes/recruit/index.ts
@@ -1,0 +1,208 @@
+import { zValidator } from '@hono/zod-validator'
+import { and, count, eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { recruitmentParticipants, recruitments, users } from '@/db/schema'
+import { apiKeyMiddleware } from '@/middlewares/apiKeyMiddleware'
+import { corsMiddleware } from '@/middlewares/corsMiddleware'
+
+const CreateRecruitmentSchema = z.object({
+	id: z.uuid(),
+	guildId: z.string(),
+	channelId: z.string(),
+	messageId: z.string(),
+	creatorId: z.string(),
+	anonymous: z.boolean(),
+	startTime: z.string().optional(),
+})
+
+const JoinRecruitmentSchema = z.object({
+	recruitmentId: z.uuid(),
+	discordId: z.string(),
+})
+
+const LeaveRecruitmentSchema = z.object({
+	recruitmentId: z.uuid(),
+	discordId: z.string(),
+})
+
+export const recruitRouter = new Hono<{ Bindings: Cloudflare.Env }>()
+	.use(corsMiddleware)
+	.use(apiKeyMiddleware)
+
+	// 募集作成
+	.post('/', zValidator('json', CreateRecruitmentSchema), async (c) => {
+		const data = c.req.valid('json')
+		const db = drizzle(c.env.DB)
+
+		// ユーザー存在確認・作成
+		await db.insert(users).values({ discordId: data.creatorId }).onConflictDoNothing()
+
+		await db.insert(recruitments).values({
+			id: data.id,
+			guildId: data.guildId,
+			channelId: data.channelId,
+			messageId: data.messageId,
+			creatorId: data.creatorId,
+			anonymous: data.anonymous ? 'true' : 'false',
+			startTime: data.startTime || null,
+			status: 'open',
+		})
+
+		return c.json({ success: true, recruitmentId: data.id })
+	})
+
+	// 募集取得
+	.get('/:id', async (c) => {
+		const recruitmentId = c.req.param('id')
+		const db = drizzle(c.env.DB)
+
+		const recruitment = await db.select().from(recruitments).where(eq(recruitments.id, recruitmentId)).get()
+
+		if (!recruitment) {
+			return c.json({ error: 'Recruitment not found' }, 404)
+		}
+
+		const participants = await db
+			.select()
+			.from(recruitmentParticipants)
+			.where(eq(recruitmentParticipants.recruitmentId, recruitmentId))
+
+		return c.json({
+			recruitment,
+			participants,
+			count: participants.length,
+		})
+	})
+
+	// 参加
+	.post('/join', zValidator('json', JoinRecruitmentSchema), async (c) => {
+		const { recruitmentId, discordId } = c.req.valid('json')
+		const db = drizzle(c.env.DB)
+
+		// 募集存在確認
+		const recruitment = await db.select().from(recruitments).where(eq(recruitments.id, recruitmentId)).get()
+
+		if (!recruitment) {
+			return c.json({ error: 'Recruitment not found' }, 404)
+		}
+
+		if (recruitment.status !== 'open') {
+			return c.json({ error: 'Recruitment is not open' }, 400)
+		}
+
+		// 現在の参加者数確認
+		const participantCount = await db
+			.select({ count: count() })
+			.from(recruitmentParticipants)
+			.where(eq(recruitmentParticipants.recruitmentId, recruitmentId))
+			.get()
+
+		const currentCount = participantCount?.count || 0
+		const capacity = Number.parseInt(recruitment.capacity, 10)
+
+		if (currentCount >= capacity) {
+			return c.json({ error: 'Recruitment is full' }, 400)
+		}
+
+		// 重複参加チェック
+		const existing = await db
+			.select()
+			.from(recruitmentParticipants)
+			.where(
+				and(eq(recruitmentParticipants.recruitmentId, recruitmentId), eq(recruitmentParticipants.discordId, discordId)),
+			)
+			.get()
+
+		if (existing) {
+			return c.json({ error: 'Already joined' }, 400)
+		}
+
+		// ユーザー存在確認・作成
+		await db.insert(users).values({ discordId }).onConflictDoNothing()
+
+		// 参加登録
+		const participantId = crypto.randomUUID()
+		await db.insert(recruitmentParticipants).values({
+			id: participantId,
+			recruitmentId,
+			discordId,
+		})
+
+		// 定員到達確認
+		const newCount = currentCount + 1
+		const isFull = newCount >= capacity
+
+		if (isFull) {
+			await db.update(recruitments).set({ status: 'full' }).where(eq(recruitments.id, recruitmentId))
+		}
+
+		// 最新の参加者リストを取得
+		const participants = await db
+			.select()
+			.from(recruitmentParticipants)
+			.where(eq(recruitmentParticipants.recruitmentId, recruitmentId))
+
+		return c.json({
+			success: true,
+			isFull,
+			count: newCount,
+			participants: participants.map((p) => p.discordId),
+		})
+	})
+
+	// キャンセル
+	.post('/leave', zValidator('json', LeaveRecruitmentSchema), async (c) => {
+		const { recruitmentId, discordId } = c.req.valid('json')
+		const db = drizzle(c.env.DB)
+
+		// 参加確認
+		const existing = await db
+			.select()
+			.from(recruitmentParticipants)
+			.where(
+				and(eq(recruitmentParticipants.recruitmentId, recruitmentId), eq(recruitmentParticipants.discordId, discordId)),
+			)
+			.get()
+
+		if (!existing) {
+			return c.json({ error: 'Not joined' }, 400)
+		}
+
+		// 参加取消
+		await db
+			.delete(recruitmentParticipants)
+			.where(
+				and(eq(recruitmentParticipants.recruitmentId, recruitmentId), eq(recruitmentParticipants.discordId, discordId)),
+			)
+
+		// 募集がfullだった場合、openに戻す
+		const recruitment = await db.select().from(recruitments).where(eq(recruitments.id, recruitmentId)).get()
+
+		if (recruitment?.status === 'full') {
+			await db.update(recruitments).set({ status: 'open' }).where(eq(recruitments.id, recruitmentId))
+		}
+
+		// 現在の参加者数
+		const participants = await db
+			.select()
+			.from(recruitmentParticipants)
+			.where(eq(recruitmentParticipants.recruitmentId, recruitmentId))
+
+		return c.json({
+			success: true,
+			count: participants.length,
+			participants: participants.map((p) => p.discordId),
+		})
+	})
+
+	// 募集終了
+	.post('/:id/close', async (c) => {
+		const recruitmentId = c.req.param('id')
+		const db = drizzle(c.env.DB)
+
+		await db.update(recruitments).set({ status: 'closed' }).where(eq(recruitments.id, recruitmentId))
+
+		return c.json({ success: true })
+	})


### PR DESCRIPTION
## Summary
- REST API endpoints for custom game recruitment feature
- Database schema for recruitments and participants (D1/SQLite)
- Changeset for minor version bump

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | /recruit | Create recruitment |
| GET | /recruit/:id | Get recruitment with participants |
| POST | /recruit/join | Join recruitment |
| POST | /recruit/leave | Leave recruitment |
| POST | /recruit/:id/close | Close recruitment |

## Database Tables
- `recruitments` - Stores recruitment info (guildId, channelId, messageId, creatorId, anonymous, capacity, startTime, status)
- `recruitment_participants` - Stores participants (recruitmentId, discordId, joinedAt)

## Test plan
- [ ] Run migration on D1
- [ ] Test create recruitment endpoint
- [ ] Test join/leave endpoints
- [ ] Test full capacity handling
- [ ] Test close endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recruitment API now available with full campaign management capabilities.
  * Users can create recruitment campaigns, view recruitment details, join and leave recruitment events, and close campaigns.
  * Built-in capacity management ensures recruitment groups respect size limits and automatically track status (open/full/closed).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->