### PR TITLE
feat: change recruit close to DELETE endpoint

### DIFF
--- a/.changeset/recruit-delete-endpoint.md
+++ b/.changeset/recruit-delete-endpoint.md
@@ -1,0 +1,9 @@
+---
+"@hexcuit/server": minor
+---
+
+募集終了時にDBから物理削除するように変更
+
+- `POST /:id/close` → `DELETE /:id` に変更
+- ステータス更新ではなくレコードを完全削除
+- CASCADE設定により参加者データも自動削除

--- a/src/routes/recruit/index.ts
+++ b/src/routes/recruit/index.ts
@@ -197,12 +197,13 @@ export const recruitRouter = new Hono<{ Bindings: Cloudflare.Env }>()
 		})
 	})
 
-	// 募集終了
-	.post('/:id/close', async (c) => {
+	// 募集終了（物理削除）
+	.delete('/:id', async (c) => {
 		const recruitmentId = c.req.param('id')
 		const db = drizzle(c.env.DB)
 
-		await db.update(recruitments).set({ status: 'closed' }).where(eq(recruitments.id, recruitmentId))
+		// CASCADE設定により recruitment_participants も自動削除される
+		await db.delete(recruitments).where(eq(recruitments.id, recruitmentId))
 
 		return c.json({ success: true })
 	})


### PR DESCRIPTION
## Summary
- 募集終了APIを `POST /:id/close` から `DELETE /:id` に変更
- ステータス更新ではなくDBから物理削除するように変更
- CASCADE設定により `recruitment_participants` も自動削除

## Test plan
- [ ] `DELETE /recruit/:id` が正常に動作することを確認
- [ ] 募集削除時に参加者データも削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recruitment closure now permanently deletes the recruitment record and all associated participant data from the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->