### PR TITLE
feat: Phase 2 - Ranked recruitment support

### DIFF
--- a/.changeset/guild-rank-phase2.md
+++ b/.changeset/guild-rank-phase2.md
@@ -1,0 +1,11 @@
+---
+"@hexcuit/server": minor
+---
+
+Phase 2: ランク戦募集機能の追加
+
+- recruitmentsテーブルにtypeカラムを追加 ('normal' | 'ranked')
+- recruitment_participantsテーブルにmainRole/subRoleカラムを追加
+- recruit APIにtype, mainRole, subRoleサポートを追加
+- /recruit/update-role エンドポイントを追加
+- LOL_ROLES定数をエクスポート

--- a/drizzle/0006_nervous_cassandra_nova.sql
+++ b/drizzle/0006_nervous_cassandra_nova.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `recruitment_participants` ADD `main_role` text;--> statement-breakpoint
+ALTER TABLE `recruitment_participants` ADD `sub_role` text;--> statement-breakpoint
+ALTER TABLE `recruitments` ADD `type` text DEFAULT 'normal' NOT NULL;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,556 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "b5f9c591-a043-4d66-82b6-7866d6752f3f",
+	"prevId": "ea3c4215-9766-4200-8f21-79c77720bf19",
+	"tables": {
+		"guild_match_participants": {
+			"name": "guild_match_participants",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"match_id": {
+					"name": "match_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"team": {
+					"name": "team",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating_before": {
+					"name": "rating_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating_after": {
+					"name": "rating_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_match_participants_match_id_guild_matches_id_fk": {
+					"name": "guild_match_participants_match_id_guild_matches_id_fk",
+					"tableFrom": "guild_match_participants",
+					"tableTo": "guild_matches",
+					"columnsFrom": ["match_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"guild_match_participants_discord_id_users_discord_id_fk": {
+					"name": "guild_match_participants_discord_id_users_discord_id_fk",
+					"tableFrom": "guild_match_participants",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_matches": {
+			"name": "guild_matches",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recruitment_id": {
+					"name": "recruitment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"winning_team": {
+					"name": "winning_team",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_matches_recruitment_id_recruitments_id_fk": {
+					"name": "guild_matches_recruitment_id_recruitments_id_fk",
+					"tableFrom": "guild_matches",
+					"tableTo": "recruitments",
+					"columnsFrom": ["recruitment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_ratings": {
+			"name": "guild_ratings",
+			"columns": {
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1500
+				},
+				"wins": {
+					"name": "wins",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"losses": {
+					"name": "losses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"placement_games": {
+					"name": "placement_games",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_ratings_discord_id_users_discord_id_fk": {
+					"name": "guild_ratings_discord_id_users_discord_id_fk",
+					"tableFrom": "guild_ratings",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"guild_ratings_guild_id_discord_id_pk": {
+					"columns": ["guild_id", "discord_id"],
+					"name": "guild_ratings_guild_id_discord_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"lol_rank": {
+			"name": "lol_rank",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"division": {
+					"name": "division",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"lol_rank_discord_id_users_discord_id_fk": {
+					"name": "lol_rank_discord_id_users_discord_id_fk",
+					"tableFrom": "lol_rank",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitment_participants": {
+			"name": "recruitment_participants",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recruitment_id": {
+					"name": "recruitment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"main_role": {
+					"name": "main_role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sub_role": {
+					"name": "sub_role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"joined_at": {
+					"name": "joined_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitment_participants_recruitment_id_recruitments_id_fk": {
+					"name": "recruitment_participants_recruitment_id_recruitments_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "recruitments",
+					"columnsFrom": ["recruitment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"recruitment_participants_discord_id_users_discord_id_fk": {
+					"name": "recruitment_participants_discord_id_users_discord_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitments": {
+			"name": "recruitments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message_id": {
+					"name": "message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"anonymous": {
+					"name": "anonymous",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'false'"
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'10'"
+				},
+				"start_time": {
+					"name": "start_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitments_creator_id_users_discord_id_fk": {
+					"name": "recruitments_creator_id_users_discord_id_fk",
+					"tableFrom": "recruitments",
+					"tableTo": "users",
+					"columnsFrom": ["creator_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"riot_accounts": {
+			"name": "riot_accounts",
+			"columns": {
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tagLine": {
+					"name": "tagLine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"riot_accounts_discord_id_unique": {
+					"name": "riot_accounts_discord_id_unique",
+					"columns": ["discord_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"riot_accounts_discord_id_users_discord_id_fk": {
+					"name": "riot_accounts_discord_id_users_discord_id_fk",
+					"tableFrom": "riot_accounts",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1765418508256,
 			"tag": "0005_cloudy_rhodey",
 			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "6",
+			"when": 1765419301122,
+			"tag": "0006_nervous_cassandra_nova",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -64,6 +64,9 @@ export const recruitments = sqliteTable('recruitments', {
 			onDelete: 'cascade',
 			onUpdate: 'cascade',
 		}),
+	type: text('type', { enum: ['normal', 'ranked'] })
+		.notNull()
+		.default('normal'),
 	anonymous: text('anonymous').notNull().default('false'),
 	capacity: text('capacity').notNull().default('10'),
 	startTime: text('start_time'),
@@ -74,6 +77,10 @@ export const recruitments = sqliteTable('recruitments', {
 		.default(sql`(current_timestamp)`)
 		.$onUpdateFn(() => sql`(current_timestamp)`),
 })
+
+// LoLロール定義
+export const LOL_ROLES = ['top', 'jungle', 'mid', 'adc', 'support'] as const
+export type LolRole = (typeof LOL_ROLES)[number]
 
 // 募集参加者テーブル
 export const recruitmentParticipants = sqliteTable('recruitment_participants', {
@@ -90,6 +97,8 @@ export const recruitmentParticipants = sqliteTable('recruitment_participants', {
 			onDelete: 'cascade',
 			onUpdate: 'cascade',
 		}),
+	mainRole: text('main_role', { enum: LOL_ROLES }),
+	subRole: text('sub_role', { enum: LOL_ROLES }),
 	joinedAt: text('joined_at').notNull().default(sql`(current_timestamp)`),
 })
 
@@ -164,7 +173,7 @@ export const guildMatchParticipants = sqliteTable('guild_match_participants', {
 			onUpdate: 'cascade',
 		}),
 	team: text('team', { enum: ['blue', 'red'] }).notNull(),
-	role: text('role', { enum: ['top', 'jungle', 'mid', 'adc', 'support'] }).notNull(),
+	role: text('role', { enum: LOL_ROLES }).notNull(),
 	ratingBefore: integer('rating_before').notNull(),
 	ratingAfter: integer('rating_after').notNull(),
 })


### PR DESCRIPTION
## Summary
- recruitmentsテーブルに`type`カラムを追加 ('normal' | 'ranked')
- recruitment_participantsテーブルに`mainRole`/`subRole`カラムを追加
- recruit APIにtype, mainRole, subRoleサポートを追加
- `/recruit/update-role` エンドポイントを追加
- `LOL_ROLES`定数をエクスポート
- マイグレーション0006を追加

## Test plan
- [ ] `POST /recruit` でtype='ranked'を指定して募集作成
- [ ] `POST /recruit/join` でmainRole/subRoleを指定して参加
- [ ] `POST /recruit/update-role` でロール更新
- [ ] `GET /recruit/:id` で参加者のロール情報が取得できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recruitment types: Create 'normal' or 'ranked' recruitments.
  * Role assignments: Participants can specify their main and sub League of Legends roles when joining.
  * Role updates: New endpoint to modify participant role assignments after joining.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->