### PR TITLE
feat: Phase 3 - 勝敗報告・Elo計算機能のAPI追加

### DIFF
--- a/.changeset/phase3-match-api.md
+++ b/.changeset/phase3-match-api.md
@@ -1,0 +1,13 @@
+---
+"@hexcuit/server": minor
+---
+
+Phase 3: 勝敗報告・Elo計算機能のサーバーAPI追加
+
+- `guildPendingMatches` テーブルを追加（投票中の試合管理）
+- `guildMatchVotes` テーブルを追加（個別投票記録）
+- 試合作成API: `POST /guild/match`
+- 試合取得API: `GET /guild/match/:id`
+- 投票API: `POST /guild/match/:id/vote`
+- 試合確定API: `POST /guild/match/:id/confirm`
+- 試合キャンセルAPI: `DELETE /guild/match/:id`

--- a/drizzle/0007_bright_sleepwalker.sql
+++ b/drizzle/0007_bright_sleepwalker.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `guild_match_votes` (
+	`pending_match_id` text NOT NULL,
+	`discord_id` text NOT NULL,
+	`vote` text NOT NULL,
+	PRIMARY KEY(`pending_match_id`, `discord_id`),
+	FOREIGN KEY (`pending_match_id`) REFERENCES `guild_pending_matches`(`id`) ON UPDATE cascade ON DELETE cascade,
+	FOREIGN KEY (`discord_id`) REFERENCES `users`(`discord_id`) ON UPDATE cascade ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `guild_pending_matches` (
+	`id` text PRIMARY KEY NOT NULL,
+	`guild_id` text NOT NULL,
+	`channel_id` text NOT NULL,
+	`message_id` text NOT NULL,
+	`status` text DEFAULT 'voting' NOT NULL,
+	`team_assignments` text NOT NULL,
+	`blue_votes` integer DEFAULT 0 NOT NULL,
+	`red_votes` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL
+);

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,688 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "67c345f2-685e-4630-a352-c0ca79f6e23e",
+	"prevId": "b5f9c591-a043-4d66-82b6-7866d6752f3f",
+	"tables": {
+		"guild_match_participants": {
+			"name": "guild_match_participants",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"match_id": {
+					"name": "match_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"team": {
+					"name": "team",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating_before": {
+					"name": "rating_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating_after": {
+					"name": "rating_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_match_participants_match_id_guild_matches_id_fk": {
+					"name": "guild_match_participants_match_id_guild_matches_id_fk",
+					"tableFrom": "guild_match_participants",
+					"tableTo": "guild_matches",
+					"columnsFrom": ["match_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"guild_match_participants_discord_id_users_discord_id_fk": {
+					"name": "guild_match_participants_discord_id_users_discord_id_fk",
+					"tableFrom": "guild_match_participants",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_match_votes": {
+			"name": "guild_match_votes",
+			"columns": {
+				"pending_match_id": {
+					"name": "pending_match_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"vote": {
+					"name": "vote",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_match_votes_pending_match_id_guild_pending_matches_id_fk": {
+					"name": "guild_match_votes_pending_match_id_guild_pending_matches_id_fk",
+					"tableFrom": "guild_match_votes",
+					"tableTo": "guild_pending_matches",
+					"columnsFrom": ["pending_match_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"guild_match_votes_discord_id_users_discord_id_fk": {
+					"name": "guild_match_votes_discord_id_users_discord_id_fk",
+					"tableFrom": "guild_match_votes",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"guild_match_votes_pending_match_id_discord_id_pk": {
+					"columns": ["pending_match_id", "discord_id"],
+					"name": "guild_match_votes_pending_match_id_discord_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_matches": {
+			"name": "guild_matches",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recruitment_id": {
+					"name": "recruitment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"winning_team": {
+					"name": "winning_team",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_matches_recruitment_id_recruitments_id_fk": {
+					"name": "guild_matches_recruitment_id_recruitments_id_fk",
+					"tableFrom": "guild_matches",
+					"tableTo": "recruitments",
+					"columnsFrom": ["recruitment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_pending_matches": {
+			"name": "guild_pending_matches",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message_id": {
+					"name": "message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'voting'"
+				},
+				"team_assignments": {
+					"name": "team_assignments",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"blue_votes": {
+					"name": "blue_votes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"red_votes": {
+					"name": "red_votes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"guild_ratings": {
+			"name": "guild_ratings",
+			"columns": {
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1500
+				},
+				"wins": {
+					"name": "wins",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"losses": {
+					"name": "losses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"placement_games": {
+					"name": "placement_games",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"guild_ratings_discord_id_users_discord_id_fk": {
+					"name": "guild_ratings_discord_id_users_discord_id_fk",
+					"tableFrom": "guild_ratings",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"guild_ratings_guild_id_discord_id_pk": {
+					"columns": ["guild_id", "discord_id"],
+					"name": "guild_ratings_guild_id_discord_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"lol_rank": {
+			"name": "lol_rank",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"division": {
+					"name": "division",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"lol_rank_discord_id_users_discord_id_fk": {
+					"name": "lol_rank_discord_id_users_discord_id_fk",
+					"tableFrom": "lol_rank",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitment_participants": {
+			"name": "recruitment_participants",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recruitment_id": {
+					"name": "recruitment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"main_role": {
+					"name": "main_role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sub_role": {
+					"name": "sub_role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"joined_at": {
+					"name": "joined_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitment_participants_recruitment_id_recruitments_id_fk": {
+					"name": "recruitment_participants_recruitment_id_recruitments_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "recruitments",
+					"columnsFrom": ["recruitment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"recruitment_participants_discord_id_users_discord_id_fk": {
+					"name": "recruitment_participants_discord_id_users_discord_id_fk",
+					"tableFrom": "recruitment_participants",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recruitments": {
+			"name": "recruitments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guild_id": {
+					"name": "guild_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message_id": {
+					"name": "message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"anonymous": {
+					"name": "anonymous",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'false'"
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'10'"
+				},
+				"start_time": {
+					"name": "start_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recruitments_creator_id_users_discord_id_fk": {
+					"name": "recruitments_creator_id_users_discord_id_fk",
+					"tableFrom": "recruitments",
+					"tableTo": "users",
+					"columnsFrom": ["creator_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"riot_accounts": {
+			"name": "riot_accounts",
+			"columns": {
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tagLine": {
+					"name": "tagLine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"riot_accounts_discord_id_unique": {
+					"name": "riot_accounts_discord_id_unique",
+					"columns": ["discord_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"riot_accounts_discord_id_users_discord_id_fk": {
+					"name": "riot_accounts_discord_id_users_discord_id_fk",
+					"tableFrom": "riot_accounts",
+					"tableTo": "users",
+					"columnsFrom": ["discord_id"],
+					"columnsTo": ["discord_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"discord_id": {
+					"name": "discord_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
 			"when": 1765419301122,
 			"tag": "0006_nervous_cassandra_nova",
 			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1765420896011,
+			"tag": "0007_bright_sleepwalker",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/routes/guild/index.ts
+++ b/src/routes/guild/index.ts
@@ -3,10 +3,26 @@ import { and, desc, eq, inArray } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/d1'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { guildRatings, users } from '@/db/schema'
+import {
+	guildMatches,
+	guildMatchParticipants,
+	guildMatchVotes,
+	guildPendingMatches,
+	guildRatings,
+	LOL_ROLES,
+	users,
+} from '@/db/schema'
 import { apiKeyMiddleware } from '@/middlewares/apiKeyMiddleware'
 import { corsMiddleware } from '@/middlewares/corsMiddleware'
-import { formatRankDisplay, getRankDisplay, INITIAL_RATING, isInPlacement, PLACEMENT_GAMES } from '@/utils/elo'
+import {
+	calculateNewRating,
+	calculateTeamAverageRating,
+	formatRankDisplay,
+	getRankDisplay,
+	INITIAL_RATING,
+	isInPlacement,
+	PLACEMENT_GAMES,
+} from '@/utils/elo'
 
 // スキーマ定義
 const GetRatingsQuerySchema = z.object({
@@ -26,6 +42,34 @@ const GetRankingQuerySchema = z.object({
 		.optional()
 		.transform((val) => (val ? Number.parseInt(val, 10) : 10)),
 })
+
+// チーム振り分け用の型
+const TeamAssignmentSchema = z.object({
+	team: z.enum(['blue', 'red']),
+	role: z.enum(LOL_ROLES),
+	rating: z.number(),
+})
+
+type TeamAssignment = z.infer<typeof TeamAssignmentSchema>
+type TeamAssignments = Record<string, TeamAssignment>
+
+// 試合作成スキーマ
+const CreateMatchSchema = z.object({
+	id: z.uuid(),
+	guildId: z.string(),
+	channelId: z.string(),
+	messageId: z.string(),
+	teamAssignments: z.record(z.string(), TeamAssignmentSchema), // { discordId: { team, role, rating } }
+})
+
+// 投票スキーマ
+const VoteSchema = z.object({
+	discordId: z.string(),
+	vote: z.enum(['blue', 'red']),
+})
+
+// 投票結果確定に必要な票数
+const VOTES_REQUIRED = 6
 
 // Guild関連のルーター
 export const guildRouter = new Hono<{ Bindings: Cloudflare.Env }>()
@@ -167,4 +211,322 @@ export const guildRouter = new Hono<{ Bindings: Cloudflare.Env }>()
 		})
 
 		return c.json({ guildId, rankings: result })
+	})
+
+	// 試合作成（投票開始）
+	.post('/match', zValidator('json', CreateMatchSchema), async (c) => {
+		const { id, guildId, channelId, messageId, teamAssignments } = c.req.valid('json')
+		const db = drizzle(c.env.DB)
+
+		// 参加者のユーザーレコードを確認・作成
+		const discordIds = Object.keys(teamAssignments)
+		for (const discordId of discordIds) {
+			await db.insert(users).values({ discordId }).onConflictDoNothing()
+		}
+
+		// pending match を作成
+		await db.insert(guildPendingMatches).values({
+			id,
+			guildId,
+			channelId,
+			messageId,
+			status: 'voting',
+			teamAssignments: JSON.stringify(teamAssignments),
+			blueVotes: 0,
+			redVotes: 0,
+		})
+
+		return c.json({ success: true, matchId: id })
+	})
+
+	// 試合取得
+	.get('/match/:id', async (c) => {
+		const matchId = c.req.param('id')
+		const db = drizzle(c.env.DB)
+
+		const match = await db.select().from(guildPendingMatches).where(eq(guildPendingMatches.id, matchId)).get()
+
+		if (!match) {
+			return c.json({ error: 'Match not found' }, 404)
+		}
+
+		const votes = await db.select().from(guildMatchVotes).where(eq(guildMatchVotes.pendingMatchId, matchId))
+
+		const teamAssignments = JSON.parse(match.teamAssignments) as TeamAssignments
+
+		return c.json({
+			match: {
+				id: match.id,
+				guildId: match.guildId,
+				channelId: match.channelId,
+				messageId: match.messageId,
+				status: match.status,
+				teamAssignments,
+				blueVotes: match.blueVotes,
+				redVotes: match.redVotes,
+				createdAt: match.createdAt,
+			},
+			votes: votes.map((v) => ({ discordId: v.discordId, vote: v.vote })),
+			votesRequired: VOTES_REQUIRED,
+		})
+	})
+
+	// 投票
+	.post('/match/:id/vote', zValidator('json', VoteSchema), async (c) => {
+		const matchId = c.req.param('id')
+		const { discordId, vote } = c.req.valid('json')
+		const db = drizzle(c.env.DB)
+
+		// 試合存在確認
+		const match = await db.select().from(guildPendingMatches).where(eq(guildPendingMatches.id, matchId)).get()
+
+		if (!match) {
+			return c.json({ error: 'Match not found' }, 404)
+		}
+
+		if (match.status !== 'voting') {
+			return c.json({ error: 'Match is not in voting state' }, 400)
+		}
+
+		// 参加者確認
+		const teamAssignments = JSON.parse(match.teamAssignments) as TeamAssignments
+		if (!teamAssignments[discordId]) {
+			return c.json({ error: 'Not a participant' }, 403)
+		}
+
+		// 既存投票確認
+		const existingVote = await db
+			.select()
+			.from(guildMatchVotes)
+			.where(and(eq(guildMatchVotes.pendingMatchId, matchId), eq(guildMatchVotes.discordId, discordId)))
+			.get()
+
+		if (existingVote) {
+			// 同じ投票なら何もしない
+			if (existingVote.vote === vote) {
+				return c.json({
+					success: true,
+					changed: false,
+					blueVotes: match.blueVotes,
+					redVotes: match.redVotes,
+				})
+			}
+
+			// 投票変更
+			await db
+				.update(guildMatchVotes)
+				.set({ vote })
+				.where(and(eq(guildMatchVotes.pendingMatchId, matchId), eq(guildMatchVotes.discordId, discordId)))
+
+			// カウント更新
+			const newBlueVotes = vote === 'blue' ? match.blueVotes + 1 : match.blueVotes - 1
+			const newRedVotes = vote === 'red' ? match.redVotes + 1 : match.redVotes - 1
+
+			await db
+				.update(guildPendingMatches)
+				.set({ blueVotes: newBlueVotes, redVotes: newRedVotes })
+				.where(eq(guildPendingMatches.id, matchId))
+
+			return c.json({
+				success: true,
+				changed: true,
+				blueVotes: newBlueVotes,
+				redVotes: newRedVotes,
+			})
+		}
+
+		// 新規投票
+		await db.insert(guildMatchVotes).values({
+			pendingMatchId: matchId,
+			discordId,
+			vote,
+		})
+
+		// カウント更新
+		const newBlueVotes = vote === 'blue' ? match.blueVotes + 1 : match.blueVotes
+		const newRedVotes = vote === 'red' ? match.redVotes + 1 : match.redVotes
+
+		await db
+			.update(guildPendingMatches)
+			.set({ blueVotes: newBlueVotes, redVotes: newRedVotes })
+			.where(eq(guildPendingMatches.id, matchId))
+
+		return c.json({
+			success: true,
+			changed: true,
+			blueVotes: newBlueVotes,
+			redVotes: newRedVotes,
+		})
+	})
+
+	// 試合確定
+	.post('/match/:id/confirm', async (c) => {
+		const matchId = c.req.param('id')
+		const db = drizzle(c.env.DB)
+
+		// 試合存在確認
+		const match = await db.select().from(guildPendingMatches).where(eq(guildPendingMatches.id, matchId)).get()
+
+		if (!match) {
+			return c.json({ error: 'Match not found' }, 404)
+		}
+
+		if (match.status !== 'voting') {
+			return c.json({ error: 'Match is not in voting state' }, 400)
+		}
+
+		// 投票数確認
+		const winningTeam = match.blueVotes >= VOTES_REQUIRED ? 'blue' : match.redVotes >= VOTES_REQUIRED ? 'red' : null
+
+		if (!winningTeam) {
+			return c.json(
+				{
+					error: 'Not enough votes',
+					blueVotes: match.blueVotes,
+					redVotes: match.redVotes,
+					required: VOTES_REQUIRED,
+				},
+				400,
+			)
+		}
+
+		const teamAssignments = JSON.parse(match.teamAssignments) as TeamAssignments
+		const participants = Object.entries(teamAssignments)
+
+		// チームごとのレートを計算
+		const blueRatings = participants.filter(([, a]) => a.team === 'blue').map(([, a]) => a.rating)
+		const redRatings = participants.filter(([, a]) => a.team === 'red').map(([, a]) => a.rating)
+		const blueAverage = calculateTeamAverageRating(blueRatings)
+		const redAverage = calculateTeamAverageRating(redRatings)
+
+		// 各参加者の新レートを計算
+		const ratingChanges: Array<{
+			discordId: string
+			team: 'blue' | 'red'
+			role: string
+			ratingBefore: number
+			ratingAfter: number
+			change: number
+		}> = []
+
+		for (const [discordId, assignment] of participants) {
+			const isBlue = assignment.team === 'blue'
+			const won = (isBlue && winningTeam === 'blue') || (!isBlue && winningTeam === 'red')
+			const opponentAverage = isBlue ? redAverage : blueAverage
+
+			// プレイスメント状況を確認
+			const currentRating = await db
+				.select()
+				.from(guildRatings)
+				.where(and(eq(guildRatings.guildId, match.guildId), eq(guildRatings.discordId, discordId)))
+				.get()
+
+			const placementGames = currentRating?.placementGames ?? 0
+			const isPlacement = isInPlacement(placementGames)
+
+			const newRating = calculateNewRating(assignment.rating, opponentAverage, won, isPlacement)
+
+			ratingChanges.push({
+				discordId,
+				team: assignment.team,
+				role: assignment.role,
+				ratingBefore: assignment.rating,
+				ratingAfter: newRating,
+				change: newRating - assignment.rating,
+			})
+		}
+
+		// トランザクション的に処理
+		// 1. guildMatches に試合記録を作成
+		const finalMatchId = crypto.randomUUID()
+		await db.insert(guildMatches).values({
+			id: finalMatchId,
+			guildId: match.guildId,
+			winningTeam,
+		})
+
+		// 2. guildMatchParticipants に参加者を記録
+		for (const rc of ratingChanges) {
+			await db.insert(guildMatchParticipants).values({
+				id: crypto.randomUUID(),
+				matchId: finalMatchId,
+				discordId: rc.discordId,
+				team: rc.team,
+				role: rc.role as 'top' | 'jungle' | 'mid' | 'adc' | 'support',
+				ratingBefore: rc.ratingBefore,
+				ratingAfter: rc.ratingAfter,
+			})
+		}
+
+		// 3. guildRatings を更新
+		for (const rc of ratingChanges) {
+			const won = rc.change > 0 || (rc.team === winningTeam && rc.change === 0)
+
+			const existing = await db
+				.select()
+				.from(guildRatings)
+				.where(and(eq(guildRatings.guildId, match.guildId), eq(guildRatings.discordId, rc.discordId)))
+				.get()
+
+			if (existing) {
+				await db
+					.update(guildRatings)
+					.set({
+						rating: rc.ratingAfter,
+						wins: won ? existing.wins + 1 : existing.wins,
+						losses: won ? existing.losses : existing.losses + 1,
+						placementGames: Math.min(existing.placementGames + 1, PLACEMENT_GAMES),
+					})
+					.where(and(eq(guildRatings.guildId, match.guildId), eq(guildRatings.discordId, rc.discordId)))
+			} else {
+				// 初回参加（レーティング未登録の場合）
+				await db.insert(guildRatings).values({
+					guildId: match.guildId,
+					discordId: rc.discordId,
+					rating: rc.ratingAfter,
+					wins: won ? 1 : 0,
+					losses: won ? 0 : 1,
+					placementGames: 1,
+				})
+			}
+		}
+
+		// 4. pendingMatch のステータスを更新
+		await db.update(guildPendingMatches).set({ status: 'confirmed' }).where(eq(guildPendingMatches.id, matchId))
+
+		return c.json({
+			success: true,
+			matchId: finalMatchId,
+			winningTeam,
+			ratingChanges: ratingChanges.map((rc) => ({
+				discordId: rc.discordId,
+				team: rc.team,
+				ratingBefore: rc.ratingBefore,
+				ratingAfter: rc.ratingAfter,
+				change: rc.change,
+				rank: formatRankDisplay(getRankDisplay(rc.ratingAfter)),
+			})),
+		})
+	})
+
+	// 試合キャンセル
+	.delete('/match/:id', async (c) => {
+		const matchId = c.req.param('id')
+		const db = drizzle(c.env.DB)
+
+		// 試合存在確認
+		const match = await db.select().from(guildPendingMatches).where(eq(guildPendingMatches.id, matchId)).get()
+
+		if (!match) {
+			return c.json({ error: 'Match not found' }, 404)
+		}
+
+		if (match.status !== 'voting') {
+			return c.json({ error: 'Match is not in voting state' }, 400)
+		}
+
+		// ステータスを cancelled に更新
+		await db.update(guildPendingMatches).set({ status: 'cancelled' }).where(eq(guildPendingMatches.id, matchId))
+
+		return c.json({ success: true })
 	})


### PR DESCRIPTION
## Summary
- `guildPendingMatches` テーブルを追加（投票中の試合管理）
- `guildMatchVotes` テーブルを追加（個別投票記録）
- 試合作成API: `POST /guild/match`
- 試合取得API: `GET /guild/match/:id`
- 投票API: `POST /guild/match/:id/vote`
- 試合確定API: `POST /guild/match/:id/confirm`（Elo計算・レート更新）
- 試合キャンセルAPI: `DELETE /guild/match/:id`

## Test plan
- [ ] マイグレーション実行確認
- [ ] 試合作成APIの動作確認
- [ ] 投票APIの動作確認（参加者のみ投票可能）
- [ ] 6票以上で試合確定されることを確認
- [ ] Elo計算が正しく行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collaborative match reporting system allowing users to create matches and assign team rosters
  * Users can vote on team assignments, with matches confirming once sufficient votes are reached
  * Pending matches can be cancelled during the voting phase
  * Automated Elo rating calculations applied upon match confirmation to update player standings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->