### PR TITLE
feat: Phase 4 - 試合履歴APIエンドポイント追加

### DIFF
--- a/.changeset/phase4-match-history-api.md
+++ b/.changeset/phase4-match-history-api.md
@@ -1,0 +1,9 @@
+---
+"@hexcuit/server": minor
+---
+
+Phase 4: 試合履歴APIエンドポイント追加
+
+- `GET /guild/match-history` - ユーザーの直近の試合履歴を取得
+  - パラメータ: `guildId`, `discordId`, `limit`（デフォルト: 5）
+  - レスポンス: 試合ごとの勝敗、レート変動情報


### PR DESCRIPTION
## Summary
- `GET /guild/match-history` エンドポイントを追加
- ユーザーの直近の試合履歴（勝敗、レート変動）を取得可能に
- Phase 3の勝敗報告機能と連携して、ユーザーの戦績追跡を実現

## Test plan
- [ ] `GET /guild/match-history?guildId=xxx&discordId=xxx` で試合履歴が取得できる
- [ ] `limit` パラメータで取得件数を制御できる
- [ ] 各試合の勝敗、レート変動が正しく計算される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve match history with recent game outcomes and rating changes per match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->