### PR TITLE
fix: ロール更新APIの部分更新対応

### DIFF
--- a/.changeset/fix-role-update-partial.md
+++ b/.changeset/fix-role-update-partial.md
@@ -1,0 +1,8 @@
+---
+"@hexcuit/server": patch
+---
+
+fix: ロール更新APIの部分更新対応
+
+- `PATCH /recruit/role` で指定されたフィールドのみ更新するように修正
+- 未指定のフィールドが意図せずnullで上書きされる問題を解消


### PR DESCRIPTION
## Summary
- `PATCH /recruit/role` で指定されたフィールドのみ更新するように修正
- 未指定のフィールド（mainRole/subRole）が意図せずnullで上書きされる問題を解消

## Test plan
- [ ] mainRoleのみ指定した場合、subRoleは変更されない
- [ ] subRoleのみ指定した場合、mainRoleは変更されない
- [ ] 両方指定した場合、両方更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the role update endpoint to correctly perform partial updates. Unspecified fields are no longer overwritten as null; only explicitly provided fields are now modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->