### PR TITLE
fix: 投票確定ロジックを過半数に変更

### DIFF
--- a/.changeset/fix-vote-majority.md
+++ b/.changeset/fix-vote-majority.md
@@ -1,0 +1,8 @@
+---
+"@hexcuit/server": patch
+---
+
+fix: 投票確定ロジックを過半数に変更
+
+- 固定6票から参加者の過半数（Math.ceil(n/2)）に変更
+- APIレスポンスにtotalParticipants, votesRequiredを追加


### PR DESCRIPTION
## Summary
- 勝敗確定に必要な票数を固定6票から参加者の過半数に変更
- 10人参加なら6票、8人参加なら5票で確定
- APIレスポンスに`totalParticipants`, `votesRequired`を追加

## Test plan
- [ ] 10人参加時、6票で勝敗確定
- [ ] 8人参加時、5票で勝敗確定
- [ ] GET /guild/match/:id のレスポンスにvotesRequired含まれる
- [ ] POST /guild/match/:id/vote のレスポンスにvotesRequired含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed voting confirmation to dynamically calculate required votes based on actual participant count instead of a fixed threshold, enabling fairer voting outcomes regardless of group size.
  * Added totalParticipants and votesRequired fields to voting API responses for transparency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->